### PR TITLE
pass through webhook `env` var

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,6 +10,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    env:
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
     steps:
     - uses: actions/checkout@v3
 


### PR DESCRIPTION
I'm not 10,000% sure this is the problem, but I suspect that env vars must be passed through from `secrets` to `.env`