### PR TITLE
add env as part of the job, not part of one step

### DIFF
--- a/.github/workflows/on_demand.yml
+++ b/.github/workflows/on_demand.yml
@@ -2,7 +2,6 @@ name: "Comicbot test"
 
 on:
   workflow_dispatch:
-    branches: [ develop ]
   push:
     branches: [ develop ]
   pull_request:
@@ -12,6 +11,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: dev
+    env:
+      WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
     steps:
     - uses: actions/checkout@v3
 
@@ -19,8 +20,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.18
-      env:
-        WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
+
     - name: Build
       run: go build -v ./comicbot.go
 


### PR DESCRIPTION
The `Set up go` step doesn't really need the WEBHOOK_URL, but rather the `Build` step. The `Run` step should echo `***` now, as secrets are hidden from cli output.